### PR TITLE
Fix validation to validate after every epoch

### DIFF
--- a/options/train_options.py
+++ b/options/train_options.py
@@ -20,8 +20,10 @@ class TrainOptions(BaseOptions):
             "--val_frequency",
             dest="val_check_interval",
             type=float,
-            default=1,
-            help="validate and potentially save a checkpoint after this many epochs"
+            default=1.0,
+            help="If float, validate (and checkpoint) after this many epochs. "
+                 "If int, validate after this many batches. If 0 or 0.0, validate "
+                 "every step."
         )
         # optimization
         parser.add_argument(


### PR DESCRIPTION
Accidentally was validating every epoch. Found out it's because if it's an int, it will validate in steps, if it's a float, it will validate in epochs. Pretty weird tbh.