### PR TITLE
Bug was from using the wrong variable name

### DIFF
--- a/models/sams_model.py
+++ b/models/sams_model.py
@@ -251,7 +251,7 @@ class SamsModel(BaseModel):
 
             # Corresponding encoding maps.
             b, n, c, h, w = enc_lblmaps.shape
-            start = nframes - fIdx  # nframes= 5,fIdx=3
+            start = n_prev - fIdx  # nframes= 5,fIdx=3
             zero_pad = torch.zeros(b, start, c, h, w).type_as(enc_lblmaps)
             # only up to the last index, which is for current frame
             prev_labelmaps_now = enc_lblmaps[:, start:-1, :, :, :]


### PR DESCRIPTION
Fixes the reported bug 

> RuntimeError: Given groups=1, weight of size 128 18 3 3, expected input[2, 20, 256, 192] to have 18 channels, but got 20 channels instead

