### PR TITLE
Modular attention now works!

### DIFF
--- a/docs/3_train.md
+++ b/docs/3_train.md
@@ -69,11 +69,20 @@ python train.py \
 #### Generator
 The SAMS-GAN generator is an encoder-decoder architecture. The outer layers start with higher resolution (hxw) and fewer features. The inner layers have lower resolution and more features. Unlike other models, SAMS does NOT use `--ngf` for generator features.
 
+**Number of Layers**
+
 The number of features in the **outer** layers equals `pow(ngf_power_base,`**`ngf_pow_outer`**`)`; by default, the outer layers have `2^6=64` features. 
 
 The number of features in the **inner** layers equals `pow(ngf_power_base, `**`ngf_pow_inner`**`)`; by default, the inner layers have `2^10=1024` features.
 
-Self-attention layers are enabled by default (self-attention is literally part of the acronym SAMS). They can be turned off with `--no_self_attn` to use vanilla Multi-Spade layers. 
+**Attention Layers**
+
+Self-Attentive Multispade (SAMs) layer indices can be chosen with:
+- `--attention_middle_indices` for middle layers
+- `--attention_decoder_indices` for decoder layers.
+
+Supports negative index selection, e.g. use `--attention_decoder_indices -1 -2` to put 
+attention in the last two decoder layers.
 
 #### Discriminators
 SAMS-GAN has two discriminators: `Multiscale` that operates on the current frame at different image resolutions, and `Temporal` that operates at the past `--n_frames_now` at a single image resolution.


### PR DESCRIPTION
- Updated encoder-decoder generation to make more sense
  - will only add an EXTRA prepending encoder layer or appending
    decoder layer IF the number of channels chosen by `ngf_pow_step` don't match up with `ngf_pow_inner` (rare case)

- Use --attention_middle_indices and --attention_decoder_indices to
  specify which layers get attention.

-  Supports negative index selection, e.g. use `--attention_decoder_indices -1 -2` to put
attention in the last two decoder layers.

**Example train command and output**
```
python train.py --name DELETEME_attention --model sams --batch 1 \
--ngf_pow_outer 3 --ngf_pow_inner 3 --num_middle 2 --attention_middle_indices -1 \
--n_frames_total 1 --n_frames_now 1 
```
```
---Initialized SAMS Generator---
Encoder Layers
	Layer 1: Encoder Conv2d with channels=8
Middle Layers
	Layer 2: Middle MultiSpade ResBlock with channels=8
	Layer 3: Middle AttentiveMultiSpade ResBlock with channels=8
Decoder Layers
	Layer 4: Decoder Conv2d with channels=3
```

Note: this runs out of memory very quickly on iceage. I could only test `--attention_middle_indices -1`, and while it initialized the model, it ran out of memory at runtime. We'll have to test it on a larger GPU to totally make sure. Though I'm worried we'll also run out of memory there. i hypothesize the SAMS layer will be too big to fit in memory; we may have to resort to simply inserting attention layers
